### PR TITLE
Allow to provide object decoding for full `message`

### DIFF
--- a/ACActionCable.podspec
+++ b/ACActionCable.podspec
@@ -8,12 +8,12 @@
 
 Pod::Spec.new do |spec|
   spec.name                  = 'ACActionCable'
-  spec.version               = '1.0.0'
+  spec.version               = '1.1.0'
   spec.license               = { :type => 'MIT', :file => 'LICENSE' }
   spec.homepage              = 'https://github.com/High5Apps/ACActionCable'
-  spec.authors               = { 'Julian Tigler' => 'high5apps@gmail.com' }
+  spec.authors               = { 'Julian Tigler' => 'high5apps@gmail.com', 'Fabian Jäger' => 'fabian@mailbutler.io' }
   spec.summary               = 'A well-tested, dependency-free Action Cable client for Rails 6'
-  spec.source                = { :git => 'https://github.com/High5Apps/ACActionCable.git', :tag => 'v1.0.0' }
+  spec.source                = { :git => 'https://github.com/High5Apps/ACActionCable.git', :tag => 'v1.1.0' }
   spec.swift_version         = '5.1'
   spec.ios.deployment_target = '11.0'
   spec.osx.deployment_target  = '10.13'

--- a/ACActionCable.xcodeproj/project.pbxproj
+++ b/ACActionCable.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -352,7 +352,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/README.md
+++ b/README.md
@@ -142,13 +142,24 @@ struct MyObject: Codable { // Must implement Decodable or Codable
     let sentAt: Date
 }
 ```
-All you have to do is register the object.
+All you have to do is register the object - either for a _single_ key or for the whole `message`.
 ```swift
 // MyClient.swift
 
 private init() {
-  // ...
-  ACMessageBodyObject.register(MyObject.self)
+  // Decode the single object for key `my_object` within `message`
+  ACMessageBodySingleObject.register(type: MyObject.self)
+}
+```
+```swift
+// ChatChannel.swift
+
+```swift
+// MyClient.swift
+
+private init() {
+  // Decode the whole `message` object
+  ACMessageBody.register(type: MyObject.self, forChannelIdentifier: channelIdentifier)
 }
 ```
 ```swift
@@ -160,8 +171,8 @@ private func handleMessage(_ message: ACMessage) {
         print("ChatChannel subscribed")
     case (.rejectSubscription, _):
         print("Server rejected ChatChannel subscription")
-    case (_, .dictionary(let dictionary)):
-        switch dictionary.object {
+    case (_, .object(let object)):
+        switch object {
         case let myObject as MyObject:
             print("\(myObject.text.debugDescription) from Sender \(myObject.senderId) at \(myObject.sentAt)")
             // "Hello, room 42!" from Sender 311 at 2020-09-19 19:57:46 +0000

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ All you have to do is register the `Codable` struct for the whole `message` obje
 
 private init() {
   // Decode the whole `message` object
-  ACMessage.register(type: MyObject.self, forChannelIdentifier: channelIdentifier)
+  ACMessage.register(type: MessageType.self, forChannelIdentifier: channelIdentifier)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 # ACActionCable
+
 [ACActionCable](https://github.com/High5Apps/ACActionCable) is a Swift 5 client for [Ruby on Rails](https://rubyonrails.org/) 6's [Action Cable](https://guides.rubyonrails.org/action_cable_overview.html) WebSocket server. It is a hard fork of [Action-Cable-Swift](https://github.com/nerzh/Action-Cable-Swift). It aims to be well-tested, dependency-free, and easy to use.
 
 ## Installation
+
 ### CocoaPods
+
 If your project doesn't use [CocoaPods](https://cocoapods.org/) yet, [follow this guide](https://guides.cocoapods.org/using/using-cocoapods.html).
 
 Add the following line to your `Podfile`:
+
 ```ruby
 pod 'ACActionCable', '~> 1.0'
 ```
+
 ACActionCable uses [semantic versioning](https://semver.org/).
 
 ## Usage
 
 ### Implement ACWebSocketProtocol
+
 You can use ACActionCable with any WebSocket library you'd like. Just create a class that implements [`ACWebSocketProtocol`](https://github.com/High5Apps/ACActionCable/blob/master/Sources/ACActionCable/ACWebSocketProtocol.swift). If you use [Starscream](https://github.com/daltoniam/Starscream), you can just copy [`ACStarscreamWebSocket`](https://github.com/High5Apps/ACActionCable/blob/master/Examples/ACStarscreamWebSocket.swift) into your project.
 
 ### Create a [singleton](https://en.wikipedia.org/wiki/Singleton_pattern) class to hold an ACClient
+
 ```swift
 // MyClient.swift
 
@@ -33,10 +40,13 @@ class MyClient {
     }
 }
 ```
+
 If you set a `connectionMonitorTimeout` and no ping is received for that many seconds, then [`ACConnectionMonitor`](https://github.com/High5Apps/ACActionCable/blob/master/Sources/ACActionCable/ACConnectionMonitor.swift) will periodically attempt to reconnect. Leave `connectionMonitorTimeout` nil to disable connection monitoring.
 
 ### Connect and disconnect
+
 You can set custom headers based on your server's requirements
+
 ```swift
 // MyClient.swift
 
@@ -52,7 +62,9 @@ func disconnect() {
     client.disconnect()
 }
 ```
+
 You probably want to connect when the user's session begins and disconnect when the user logs out.
+
 ```swift
 // User.swift
 
@@ -68,6 +80,7 @@ func logOut() {
 ```
 
 ### Subscribe and unsubscribe
+
 ```swift
 // MyClient.swift
 
@@ -83,6 +96,7 @@ func unsubscribe(from subscription: ACSubscription) {
     client.unsubscribe(from: subscription)
 }
 ```
+
 ```swift
 // ChatChannel.swift
 
@@ -97,7 +111,7 @@ class ChatChannel {
         let channelIdentifier = ACChannelIdentifier(channelName: "ChatChannel", identifier: ["room_id": roomId])!
         subscription = MyClient.shared.subscribe(to: channelIdentifier, with: handleMessage(_:))
     }
-    
+
     func unsubscribe() {
         guard let subscription = subscription else { return }
         MyClient.shared.unsubscribe(from: subscription)
@@ -116,15 +130,18 @@ class ChatChannel {
     }
 }
 ```
+
 Subscriptions are resubscribed on reconnection, so beware that `.confirmSubscription` may be called multiple times per subscription.
 
 ### Register your [`Decodable`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types) messages
+
 ACActionCable automatically decodes your models. For example, if your server broadcasts the following message:
+
 ```json
 {
-  "identifier":"{\"channel\":\"ChatChannel\",\"room_id\":42}",
-  "message":{
-    "my_object":{
+  "identifier": "{\"channel\":\"ChatChannel\",\"room_id\":42}",
+  "message": {
+    "my_object": {
       "sender_id": 311,
       "text": "Hello, room 42!",
       "sent_at": 1600545466.294104
@@ -132,7 +149,11 @@ ACActionCable automatically decodes your models. For example, if your server bro
   }
 }
 ```
-Then ACActionCable can automatically decode it into the following object:
+
+Then ACActionCable provides two different approaches to automatically decode it:
+
+#### A) Automatically decode single key of `message`
+
 ```swift
 // MyObject.swift
 
@@ -142,7 +163,9 @@ struct MyObject: Codable { // Must implement Decodable or Codable
     let sentAt: Date
 }
 ```
-All you have to do is register the object - either for a _single_ key or for the whole `message`.
+
+All you have to do is register the `Codable` struct for a _single_ key. The name of the `struct` must match the name of that **single** key.
+
 ```swift
 // MyClient.swift
 
@@ -151,17 +174,7 @@ private init() {
   ACMessageBodySingleObject.register(type: MyObject.self)
 }
 ```
-```swift
-// ChatChannel.swift
 
-```swift
-// MyClient.swift
-
-private init() {
-  // Decode the whole `message` object
-  ACMessageBody.register(type: MyObject.self, forChannelIdentifier: channelIdentifier)
-}
-```
 ```swift
 // ChatChannel.swift
 
@@ -183,47 +196,111 @@ private func handleMessage(_ message: ACMessage) {
         break
     }
 }
-
 ```
 
-### Send messages
-ACActionCable automatically encodes your [`Encodable`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types) objects too:
-```swift
-// MyObject.swift
+If the `message` object sent from the server contains more than a single key, you have another option for automatic decoding:
 
-struct MyObject: Codable { // Must implement Encodable or Codable
+#### B) Automatically decode whole `message` object
+
+```swift
+// MessageType.swift
+
+struct MessageType: Codable { // Must implement Decodable or Codable
+    let myObject: MyObject
+}
+
+struct MyObject: Codable { // Must implement Decodable or Codable
     let senderId: Int
     let text: String
     let sentAt: Date
 }
 ```
+
+All you have to do is register the `Codable` struct for the whole `message` object.
+
+```swift
+// MyClient.swift
+
+private init() {
+  // Decode the whole `message` object
+  ACMessage.register(type: MyObject.self, forChannelIdentifier: channelIdentifier)
+}
+```
+
+The `channelIdentifier` must match the one the handler is subscribing to, because all incoming `message` objects for that channel will be decoded according to `MessageType`.
+
+```swift
+// ChatChannel.swift
+
+private func handleMessage(_ message: ACMessage) {
+    switch (message.type, message.body) {
+    case (.confirmSubscription, _):
+        print("ChatChannel subscribed")
+    case (.rejectSubscription, _):
+        print("Server rejected ChatChannel subscription")
+    case (_, .object(let object)):
+        switch object {
+        case let message as MessageType:
+            print("\(message.myObject.text.debugDescription) from Sender \(message.myObject.senderId) at \(message.myObject.sentAt)")
+            // "Hello, room 42!" from Sender 311 at 2020-09-19 19:57:46 +0000
+        default:
+            print("Warning: ChatChannel ignored message")
+        }
+    default:
+        break
+    }
+}
+```
+
+### Send messages
+
+ACActionCable automatically encodes your [`Encodable`](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types) objects too:
+
+```swift
+// MyObject.swift
+
+struct MyObject: Codable { // Must implement Encodable or Codable
+    let action: String
+    let senderId: Int
+    let text: String
+    let sentAt: Date
+}
+```
+
 ```swift
 // ChatChannel.swift
 
 func speak(_ text: String) {
-    let myObject = MyObject(senderId: 99, text: text, sentAt: Date())
-    subscription?.send(actionName: "speak", object: myObject)
+    let myObject = MyObject(action: "speak", senderId: 99, text: text, sentAt: Date())
+    subscription?.send(object: myObject)
 }
 ```
+
 Calling `channel.speak("my message")` would cause the following to be sent:
+
 ```json
 {
-    "command":"message",
-    "data":"{\"action\":\"speak\",\"my_object\":{\"sender_id\":99,\"sent_at\":1600545466.294104,\"text\":\"my message\"}}",
-    "identifier":"{\"channel\":\"ChatChannel\",\"room_id\":42}"
+  "command": "message",
+  "data": "{\"action\":\"speak\",\"my_object\":{\"sender_id\":99,\"sent_at\":1600545466.294104,\"text\":\"my message\"}}",
+  "identifier": "{\"channel\":\"ChatChannel\",\"room_id\":42}"
 }
 ```
 
 ### (Optional) Modify encoder/decoder date formatting
+
 By default, `Date` objects are encoded or decoded using [`.secondsSince1970`](https://developer.apple.com/documentation/foundation/jsonencoder/dateencodingstrategy/secondssince1970). If you need to change to another format:
+
 ```swift
 ACCommand.encoder.dateEncodingStrategy = .iso8601 // for dates like "2020-09-19T20:09:04Z"
-ACMessage.decoder.dateDecodingStrategy = .iso8601 
+ACMessage.decoder.dateDecodingStrategy = .iso8601
 ```
+
 Note that `.iso8601` is quite strict and doesn't allow fractional seconds. If you need them, consider using `.secondsSince1970`, `millisecondsSince1970`, `.formatted`, or `.custom`.
 
 ### (Optional) Add an ACClientTap
+
 If you need to listen to the internal state of `ACClient`, use `ACClientTap`.
+
 ```swift
 // MyClient.swift
 
@@ -244,4 +321,5 @@ private init() {
 ```
 
 ## Contributing
+
 Instead of opening an issue, please fix it yourself and then [create a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Please add new tests for your feature or fix, and don't forget to make sure that all the tests pass!

--- a/Sources/ACActionCable/ACChannelIdentifier.swift
+++ b/Sources/ACActionCable/ACChannelIdentifier.swift
@@ -16,7 +16,7 @@ public struct ACChannelIdentifier {
     
     // MARK: Initialization
     
-    public init?(channelName: String, identifier: [String: Any]) {
+    public init?(channelName: String, identifier: [String: Any] = [:]) {
         var dictionary = identifier
         dictionary["channel"] = channelName
         self.dictionary = dictionary

--- a/Sources/ACActionCable/ACMessage.swift
+++ b/Sources/ACActionCable/ACMessage.swift
@@ -13,6 +13,8 @@ public struct ACMessage: Decodable {
     
     // MARK: Properties
     
+    private static var messageTypes: [String: Decodable.Type] = [:]
+
     public static var decoder: JSONDecoder = {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
@@ -33,12 +35,33 @@ public struct ACMessage: Decodable {
         case disconnectReason = "reason"
         case reconnect
     }
-    
+
+    public static func register<A: Decodable>(type: A.Type, forChannelIdentifier identifier: ACChannelIdentifier) {
+        messageTypes[identifier.string] = type
+    }
+
     // MARK: Initialization
     
     init?(string: String) {
         guard let data = string.data(using: .utf8), let message = try? Self.decoder.decode(ACMessage.self, from: data) else { return nil }
         self = message
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        type = try container.decodeIfPresent(ACMessageType.self, forKey: .type)
+        identifier = try container.decodeIfPresent(ACChannelIdentifier.self, forKey: .identifier)
+        disconnectReason = try container.decodeIfPresent(ACDisconnectReason.self, forKey: .disconnectReason)
+        reconnect = try container.decodeIfPresent(Bool.self, forKey: .reconnect)
+
+        // special handling for message BODY
+        if let identifier, let messageType = Self.messageTypes[identifier.string] {
+            let bodyObject = try container.decodeIfPresent(messageType, forKey: .body)
+            body = ACMessageBody.object(bodyObject)
+        } else {
+            body = try container.decodeIfPresent(ACMessageBody.self, forKey: .body)
+        }
     }
 }
 
@@ -57,14 +80,14 @@ public enum ACMessageType: String, Decodable {
 
 public enum ACMessageBody: Decodable {
     case ping(Int)
-    case dictionary(ACMessageBodyObject)
-    
+    case object(Any?)
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let value = try? container.decode(Int.self) {
             self = .ping(value)
-        } else if let value = try? container.decode(ACMessageBodyObject.self) {
-            self = .dictionary(value)
+        } else if let value = try? container.decode(ACMessageBodySingleObject.self) {
+            self = .object(value.object)
         } else {
             throw DecodingError.typeMismatch(ACMessageBody.self, DecodingError.Context(codingPath: container.codingPath, debugDescription: "Unable to parse message body"))
         }
@@ -73,18 +96,18 @@ public enum ACMessageBody: Decodable {
 
 // MARK: ACMessageBodyObject
 
-public struct ACMessageBodyObject: Decodable {
+public struct ACMessageBodySingleObject: Decodable {
     public let object: Any?
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DynamicKey.self)
         guard container.allKeys.count == 1, let firstKey = container.allKeys.first else {
-            throw DecodingError.typeMismatch(ACMessageBodyObject.self, DecodingError.Context(codingPath: container.codingPath, debugDescription: "Expected message container to only have one top-level key"))
+            throw DecodingError.typeMismatch(ACMessageBodySingleObject.self, DecodingError.Context(codingPath: container.codingPath, debugDescription: "Expected message container to only have one top-level key"))
         }
         
         let key = firstKey.stringValue
         guard let decoder = Self.decoders[key] else {
-            throw DecodingError.typeMismatch(ACMessageBodyObject.self, DecodingError.Context(codingPath: container.codingPath, debugDescription: "No message decoder registered for key: \(key)"))
+            throw DecodingError.typeMismatch(ACMessageBodySingleObject.self, DecodingError.Context(codingPath: container.codingPath, debugDescription: "No message decoder registered for key: \(key)"))
         }
         
         object = try? decoder(container)
@@ -93,12 +116,12 @@ public struct ACMessageBodyObject: Decodable {
     private typealias BodyDecoder = (KeyedDecodingContainer<DynamicKey>) throws -> Any
     private static var decoders: [String: BodyDecoder] = [:]
     
-    public static func register<A: Decodable>(_ type: A.Type) {
+    public static func register<A: Decodable>(type: A.Type, forKey key: String? = nil) {
         let pascalCaseTypeName = String(describing: type)
         let camelCaseTypeName = pascalCaseTypeName.prefix(1).lowercased() + pascalCaseTypeName.dropFirst()
 
         decoders[camelCaseTypeName] = { container in
-            try container.decode(A.self, forKey: DynamicKey(stringValue: camelCaseTypeName)!)
+            try container.decode(A.self, forKey: DynamicKey(stringValue: key ?? camelCaseTypeName)!)
         }
     }
 }

--- a/Sources/ACActionCable/ACMessage.swift
+++ b/Sources/ACActionCable/ACMessage.swift
@@ -40,6 +40,14 @@ public struct ACMessage: Decodable {
         messageTypes[identifier.string] = type
     }
 
+    public static func unregisterType(forChannelIdentifier identifier: ACChannelIdentifier) {
+        messageTypes.removeValue(forKey: identifier.string)
+    }
+
+    public static func unregisterAllTypes() {
+        messageTypes.removeAll()
+    }
+
     // MARK: Initialization
     
     init?(string: String) {

--- a/Sources/ACActionCable/ACSubscription.swift
+++ b/Sources/ACActionCable/ACSubscription.swift
@@ -26,13 +26,13 @@ public class ACSubscription {
     
     // MARK: Sending
     
-    public func send<T: Encodable>(action: String, object: T, completion: ACEventHandler? = nil) {
-        guard let command = ACCommand(type: .message, identifier: channelIdentifier, action: action, object: object) else { return }
+    public func send<T: Encodable>(object: T, completion: ACEventHandler? = nil) {
+        guard let command = ACCommand(type: .message, identifier: channelIdentifier, object: object) else { return }
         client.send(command, completion: completion)
     }
     
     public func send(action: String, completion: ACEventHandler? = nil) {
-        guard let command = ACCommand(type: .message, identifier: self.channelIdentifier, action: action) else { return }
+        guard let command = ACCommand(type: .message, identifier: channelIdentifier, action: action) else { return }
         client.send(command)
     }
 }

--- a/Tests/ACActionCableTests/ACCommandTests.swift
+++ b/Tests/ACActionCableTests/ACCommandTests.swift
@@ -31,10 +31,19 @@ class ACCommandTests: XCTestCase {
         }
         
         let date = Date(timeIntervalSince1970: 1600545466)
-        let format = #"{"command":"message","data":"{\"action\":\"my_action\",\"my_object\":{\"my_date\":%d,\"my_int\":1,\"my_string\":\"test\"}}","identifier":"{\"channel\":\"TestChannel\",\"test_id\":42}"}"#
+        let format = #"{"command":"message","data":"{\"my_date\":%d,\"my_int\":1,\"my_string\":\"test\"}","identifier":"{\"channel\":\"TestChannel\",\"test_id\":42}"}"#
         let expected = String(format: format, Int(date.timeIntervalSince1970))
         let identifier = ACChannelIdentifier(channelName: "TestChannel", identifier: ["test_id": 42])!
-        let command = ACCommand(type: .message, identifier: identifier, action: "my_action", object: MyObject(myInt: 1, myString: "test", myDate: date))
+        let command = ACCommand(type: .message, identifier: identifier, object: MyObject(myInt: 1, myString: "test", myDate: date))
+        XCTAssertEqual(expected, command?.string)
+    }
+
+    func testShouldEncodeActionMessage() throws {
+        let date = Date(timeIntervalSince1970: 1600545466)
+        let format = #"{"command":"message","data":"{\"action\":\"my_action\"}","identifier":"{\"channel\":\"TestChannel\",\"test_id\":42}"}"#
+        let expected = String(format: format, Int(date.timeIntervalSince1970))
+        let identifier = ACChannelIdentifier(channelName: "TestChannel", identifier: ["test_id": 42])!
+        let command = ACCommand(type: .message, identifier: identifier, action: "my_action")
         XCTAssertEqual(expected, command?.string)
     }
 }

--- a/Tests/ACActionCableTests/ACMessageTests.swift
+++ b/Tests/ACActionCableTests/ACMessageTests.swift
@@ -8,7 +8,11 @@
 import XCTest
 
 class ACMessageTests: XCTestCase {
-    
+
+    override func setUp() async throws {
+        ACMessage.unregisterAllTypes()
+    }
+
     func testShouldDecodeWelcome() throws {
         let string = #"{"type":"welcome"}"#
         let message = ACMessage(string: string)!

--- a/Tests/ACActionCableTests/ACSubscriptionTests.swift
+++ b/Tests/ACActionCableTests/ACSubscriptionTests.swift
@@ -21,13 +21,24 @@ class ACSubscriptionTests: XCTestCase {
             let myProperty: Int
         }
 
-        let expectedSend = #"{"command":"message","data":"{\"action\":\"speak\",\"my_object\":{\"my_property\":1}}","identifier":"{\"channel\":\"TestChannel\",\"test_id\":32}"}"#
+        let expectedSend = #"{"command":"message","data":"{\"my_property\":1}","identifier":"{\"channel\":\"TestChannel\",\"test_id\":32}"}"#
         let object = MyObject(myProperty: 1)
         let (subscription, expectation) = expectMessage(expectedSend)
-        subscription.send(action: "speak", object: object)
+        subscription.send(object: object)
         wait(for: [expectation], timeout: 1)
     }
-    
+
+    func testShouldSendWithAction() throws {
+        struct MyObject: Encodable {
+            let myProperty: Int
+        }
+
+        let expectedSend = #"{"command":"message","data":"{\"action\":\"my_action\"}","identifier":"{\"channel\":\"TestChannel\",\"test_id\":32}"}"#
+        let (subscription, expectation) = expectMessage(expectedSend)
+        subscription.send(action: "my_action")
+        wait(for: [expectation], timeout: 1)
+    }
+
     private func expectMessage(_ expectedSend: String) -> (ACSubscription, XCTestExpectation) {
         let expectedSubscribe = #"{"command":"subscribe","identifier":"{\"channel\":\"TestChannel\",\"test_id\":32}"}"#
         let subscribe = expectation(description: "Subscribe")


### PR DESCRIPTION
Instead of only allowing a single key in the `message`, this proposal generalizes this concept and allows to also provide a type to decode the full `message` as a JSON object.